### PR TITLE
FLAT-2756 Add css to hide the print button from the viewer

### DIFF
--- a/web/viewer.css
+++ b/web/viewer.css
@@ -46,6 +46,10 @@ select {
   outline: none;
 }
 
+button#print {
+  display: none;
+}
+
 .hidden {
   display: none !important;
 }


### PR DESCRIPTION
- The print button in the pdf.js viewer should be hidden as it doesn't support annotations and displays empty pages in the print preview.